### PR TITLE
Change twomes_api tag back to latest

### DIFF
--- a/api/v1/tst/docker-compose.yml
+++ b/api/v1/tst/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   twomes-api-v1-tst:
-    image: ghcr.io/energietransitie/twomes_api:v1.1.0 # Latest API v1 version.
+    image: ghcr.io/energietransitie/twomes_api:latest
     container_name: twomes-api-v1-tst
     labels:
       - traefik.http.routers.twomes-api-v1-tst.rule=Host(`api.tst.energietransitiewindesheim.nl`) || (Host(`api.tst.energietransitiewindesheim.nl`) && PathPrefix(`/v1`))


### PR DESCRIPTION
This is useful to have, because we can still update the test environment