### PR TITLE
Fix network syntax in docker-compose.yml

### DIFF
--- a/api/v2/prd/docker-compose.yml
+++ b/api/v2/prd/docker-compose.yml
@@ -21,9 +21,10 @@ services:
     restart: unless-stopped
     volumes:
       - data:/data
+
 networks:
   web:
-    external:
-      name: web
+    external: true
+
 volumes:
   data: {}

--- a/api/v2/tst/docker-compose.yml
+++ b/api/v2/tst/docker-compose.yml
@@ -21,9 +21,10 @@ services:
     restart: unless-stopped
     volumes:
       - data:/data
+
 networks:
   web:
-    external:
-      name: web
+    external: true
+
 volumes:
   data: {}


### PR DESCRIPTION
network.external.name was deprecated.